### PR TITLE
Remove Unused CSS Import for headings.css

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -2,7 +2,6 @@
 
 /* Import External CSS Files */
 @import url("header.css");
-@import url("headings.css");
 @import url("intro.css");
 @import url("form.css");
 @import url("gallery.css");


### PR DESCRIPTION
### Objective:
Remove the import statement for "headings.css" in the main stylesheet to clean up unused code and improve loading efficiency.

### Scope of Changes:

1. **File `style/main.css`:**
   - Removed the import statement for "headings.css".